### PR TITLE
Use @_disfavoredOverload reducing ambiguous errors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "037b70291941fe43de668066eb6fb802c5e181d2",
-          "version": "1.1.1"
+          "revision": "c9a9bf061d713c91ee9974fa8a6afe413acfd0e9",
+          "version": "1.2.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-kit",
         "state": {
           "branch": null,
-          "revision": "8a20f1dd111fa715d60e79fcfc38d8229c88392e",
-          "version": "1.6.0"
+          "revision": "2227231901db2c4d73c0a92cc088447f2a41030d",
+          "version": "1.7.1"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "c76a9a5085bfc22882f8cff88189662af30806e8",
-          "version": "1.12.3"
+          "revision": "e9627350bdb85bde7e0dc69a29799e40961ced72",
+          "version": "1.13.0"
         }
       },
       {
@@ -164,12 +164,21 @@
         }
       },
       {
+        "package": "swift-nio-transport-services",
+        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
+        "state": {
+          "branch": null,
+          "revision": "d40a5e34e5b35f4f961cb34aeb2e0a02f42a945f",
+          "version": "1.8.0"
+        }
+      },
+      {
         "package": "vapor",
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "281b50935a7c3ac86916f69cb2851e55915ddf07",
-          "version": "4.27.1"
+          "revision": "c4861a4bf1a254280d402a66d4751d1a150e0ade",
+          "version": "4.27.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent", from: "4.0.0"),
         .package(url: "https://github.com/vapor/fluent-kit", from: "1.4.1"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.1.0"),
-        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.0.0-beta")
+        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.0.0")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ app.routes.get("foo", use: route)
 import Sublimate
 import Vapor
 
-let route = sublimate(in: .transaction) { rq -> Void in
-    // ^^ if you return `Void` we send back an HTTP 200
+let route = sublimate(in: .transaction) { rq in
+    // ^^ if you return `Void` we send back an HTTP 200 (`Void` is chosen by Swift if you specify no return type)
     // Use `.transaction` to have the whole route in a transaction
 
     let rows = try rq.raw(sql: """

--- a/Sources/sublimate().swift
+++ b/Sources/sublimate().swift
@@ -19,6 +19,7 @@ import class Vapor.Request
 
  - Parameter in: Provide `.transaction` to have this route contained in a database transaction.
  */
+@_disfavoredOverload
 public func sublimate(in options: CO₂DB.RouteOptions? = nil, use closure: @escaping (CO₂) throws -> Response) -> (Request) throws -> EventLoopFuture<Response> {
     return { rq in
         options.go(on: rq) { db in
@@ -60,6 +61,7 @@ public func sublimate(in options: CO₂DB.RouteOptions? = nil, use closure: @esc
 
  - Parameter in: Provide `.transaction` to have this route contained in a database transaction.
  */
+@_disfavoredOverload
 public func sublimate<User: Authenticatable>(in options: CO₂DB.RouteOptions? = nil, use closure: @escaping (CO₂, User) throws -> Response) -> (Request) throws -> EventLoopFuture<Response> {
     return { rq in
         let user = try rq.auth.require(User.self)
@@ -82,6 +84,7 @@ public func sublimate<User: Authenticatable>(in options: CO₂DB.RouteOptions? =
 
  - Parameter in: Provide `.transaction` to have this route contained in a database transaction.
  */
+@_disfavoredOverload
 public func sublimate<E: ResponseEncodable>(in options: CO₂DB.RouteOptions? = nil, use closure: @escaping (CO₂) throws -> E) -> (Request) throws -> EventLoopFuture<Response> {
     return { rq in
         options.go(on: rq) { db in
@@ -104,6 +107,7 @@ public func sublimate<E: ResponseEncodable>(in options: CO₂DB.RouteOptions? = 
 
  - Parameter in: Provide `.transaction` to have this route contained in a database transaction.
  */
+@_disfavoredOverload
 public func sublimate<E: ResponseEncodable, User: Authenticatable>(in options: CO₂DB.RouteOptions? = nil, use closure: @escaping (CO₂, User) throws -> E) -> (Request) throws -> EventLoopFuture<Response> {
     return { rq in
         let user = try rq.auth.require(User.self)

--- a/Tests/CO₂Tests.swift
+++ b/Tests/CO₂Tests.swift
@@ -31,7 +31,7 @@ final class CO₂Tests: CO₂TestCase {
     func testVoid() throws {
         var foo = false
 
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             XCTAssertFalse(rq.db.inTransaction)
             foo = true
         })
@@ -67,7 +67,7 @@ final class CO₂Tests: CO₂TestCase {
     func testTransactionVoid() throws {
         var foo = false
 
-        app.routes.get("foo", use: sublimate(in: .transaction) { rq -> Void in
+        app.routes.get("foo", use: sublimate(in: .transaction) { rq in
             XCTAssert(rq.db.inTransaction)
             foo = true
         })
@@ -212,7 +212,7 @@ extension CO₂Tests {
 extension CO₂Tests {
     // for code coverage
     func testProperties() throws {
-        app.routes.get("foo", use: sublimate(in: .transaction) { rq -> Void in
+        app.routes.get("foo", use: sublimate(in: .transaction) { rq in
             _ = rq.auth
             _ = rq.headers
             _ = rq.content

--- a/Tests/NIOTests.swift
+++ b/Tests/NIOTests.swift
@@ -19,7 +19,7 @@ class NIOTests: CO₂TestCase {
     }
 
     func testCollectionFlattenVoid() throws {
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             let f1 = rq.eventLoop.makeSucceededFuture(())
             let f2 = rq.eventLoop.makeSucceededFuture(())
             return try [f1, f2].flatten(on: rq)
@@ -31,7 +31,7 @@ class NIOTests: CO₂TestCase {
     }
 
     func testFail() throws {
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             throw Abort(.notFound)
         })
 

--- a/Tests/SublimateModelMiddlewareTests.swift
+++ b/Tests/SublimateModelMiddlewareTests.swift
@@ -72,7 +72,7 @@ class SublimateModelMiddlewareTests: CO₂TestCase {
 
         app.databases.middleware.use(MW())
 
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             XCTAssertFalse(rq.db.inTransaction)
             let model = try Model().create(on: rq)
             XCTAssertEqual(try Model.query(on: rq).first(or: .abort).id, .zero)
@@ -95,7 +95,7 @@ class SublimateModelMiddlewareTests: CO₂TestCase {
 
         app.databases.middleware.use(MW())
 
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             XCTAssertFalse(rq.db.inTransaction)
             let model = try SoftDeleteModel().create(on: rq)
             XCTAssertEqual(try SoftDeleteModel.query(on: rq).first(or: .abort).id, .zero)
@@ -118,7 +118,7 @@ class SublimateModelMiddlewareTests: CO₂TestCase {
 
         app.databases.middleware.use(MW())
 
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             XCTAssertFalse(rq.db.inTransaction)
             let model = try SoftDeleteModel().create(on: rq)
             XCTAssertEqual(try SoftDeleteModel.query(on: rq).first(or: .abort).id, .zero)
@@ -144,7 +144,7 @@ class SublimateModelMiddlewareTests: CO₂TestCase {
         app.databases.middleware.use(MW1())
         app.databases.middleware.use(MW2())
 
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             do {
                 XCTAssertFalse(rq.db.inTransaction)
                 let model = try Model().create(on: rq)

--- a/Tests/SublimateRawBuilderTests.swift
+++ b/Tests/SublimateRawBuilderTests.swift
@@ -5,7 +5,7 @@ import Vapor
 
 class SublimateRawBuilderTests: CO₂TestCase {
     func testRun() throws {
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             try rq.raw(sql: "CREATE TABLE foo (id INTEGER PRIMARY KEY)").run()
             try rq.run(sql: "INSERT INTO foo (id) VALUES (0)")
         })
@@ -16,7 +16,7 @@ class SublimateRawBuilderTests: CO₂TestCase {
     }
 
     func testFirst() throws {
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             try rq.raw(sql: "CREATE TABLE foo (id INTEGER PRIMARY KEY)").run()
             try rq.raw(sql: "INSERT INTO foo (id) VALUES (0)").run()
             _ = try rq.raw(sql: "SELECT * FROM foo").first()
@@ -28,7 +28,7 @@ class SublimateRawBuilderTests: CO₂TestCase {
     }
 
     func testFirstDecoding() throws {
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             try rq.raw(sql: "CREATE TABLE foo (id INTEGER PRIMARY KEY)").run()
             try rq.raw(sql: "INSERT INTO foo (id) VALUES (0)").run()
             _ = try rq.raw(sql: "SELECT * FROM foo").first(decoding: Row.self)
@@ -40,7 +40,7 @@ class SublimateRawBuilderTests: CO₂TestCase {
     }
 
     func testAll() throws {
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             try rq.raw(sql: "CREATE TABLE foo (id INTEGER PRIMARY KEY)").run()
             try rq.raw(sql: "INSERT INTO foo (id) VALUES (0)").run()
             _ = try rq.raw(sql: "SELECT * FROM foo").all()
@@ -52,7 +52,7 @@ class SublimateRawBuilderTests: CO₂TestCase {
     }
 
     func testAllDecoding() throws {
-        app.routes.get("foo", use: sublimate { rq -> Void in
+        app.routes.get("foo", use: sublimate { rq in
             try rq.raw(sql: "CREATE TABLE foo (id INTEGER PRIMARY KEY)").run()
             try rq.raw(sql: "INSERT INTO foo (id) VALUES (0)").run()
             _ = try rq.raw(sql: "SELECT * FROM foo").all(decoding: Row.self)


### PR DESCRIPTION
This is a private attribute, but historically these do not get removed. Worth it for making Sublimate *even* more pleasant to use.

Here, Swift will now pick the `Void` return as a default for `sublimate()` use thus allowing the developer to make more progress without having to specify the return for the closure before they have written code that can actually return.